### PR TITLE
PyPI setup file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019.122:
+	- Add setup.py to allow pushing a installer package to PyPi.
+
 2018.163: 2.7.1
 	- Add Windows compatibility bits and Makefile.win (Nmake) files.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mseedindex - Synchronize Mini-SEED with database
+# mseedindex - Synchronize miniSEED with database
 
-This program reads Mini-SEED files, creates an index of the available
+This program reads miniSEED files, creates an index of the available
 data and stores this information into a database.  The index includes
 details such as identifers, time ranges, file names, location within files,
 and additional details.  The database can be either

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,128 @@
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+from setuptools.command.develop import develop
+from io import open
+from tempfile import gettempdir
+import subprocess
+import os
+import sys
+import zipfile
+import glob
+import shutil
+import re
+
+module_name = 'mseedindex'
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+with open(os.path.join(here, "README.md"), encoding='utf-8') as fh:
+    long_description = fh.read()
+
+with open(os.path.join(here, "src/mseedindex.c"), encoding='utf-8') as fh:
+    # extract mseedindex.c version from the source code
+    result = re.search('#define VERSION "(.*)"', fh.read())
+    version = result.group(1)
+
+# python 2 / 3 compatibility
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+
+class InstallBase():
+
+    def get_virtualenv_path(self):
+        """Used to work out path to install compiled binaries to."""
+        return os.path.join(sys.prefix, 'bin')
+
+    def download_mseedindex(self):
+        # download mseed index zip ball
+        url = 'https://api.github.com/repos/iris-edu/mseedindex/zipball'
+        temp_dir = gettempdir()
+        mseed_index_zip = os.path.join(temp_dir, "mseedindex.zip")
+        f = urlopen(url)
+        data = f.read()
+        with open(mseed_index_zip, "wb") as fd:
+            fd.write(data)
+        # extract zip in system temporary directory
+        zip_ref = zipfile.ZipFile(mseed_index_zip, 'r')
+        exract_path = os.path.join(temp_dir, 'mseedindex')
+        zip_ref.extractall(exract_path)
+        zip_ref.close()
+        # return extracted zip file
+        return glob.glob(os.path.join(exract_path, '*'))[0]
+
+    def compile_and_install_mseedindex(self, mseedindex_path):
+        """Used the subprocess module to compile/install mseedindex."""
+        # compile the software
+        cmd = "WITHOUTPOSTGRESQL=1 CFLAGS='-O2' make"
+        subprocess.check_call(cmd, cwd=mseedindex_path, shell=True)
+        mseedindex_binary = os.path.join(mseedindex_path, 'mseedindex')
+        mseedindex_binary_dest = self.get_mseedindex_path()
+        shutil.copy(mseedindex_binary, mseedindex_binary_dest)
+        return mseedindex_binary_dest
+
+    def install_mseedindex(self):
+        try:
+            mseedindex_path = self.download_mseedindex()
+            mseedindex_binary = self.compile_and_install_mseedindex(
+                                                            mseedindex_path)
+            print("Successfully installed mseedindex at {}"
+                  .format(mseedindex_binary))
+        except Exception as e:
+            raise Exception("Failed to install mseedindex - {}"
+                            .format(e))
+
+    def get_mseedindex_path(self):
+        venv = self.get_virtualenv_path()
+        mseedindex_binary = os.path.join(venv, 'mseedindex')
+        return mseedindex_binary
+
+
+class DevelopMSeedIndex(develop, InstallBase):
+
+    def initialize_options(self):
+        develop.initialize_options(self)
+
+    def run(self):
+        self.install_mseedindex()
+        develop.run(self)
+
+
+class InstallMSeedIndex(install, InstallBase):
+
+    def initialize_options(self):
+        install.initialize_options(self)
+
+    def run(self):
+        self.install_mseedindex()
+        install.run(self)
+
+
+setup(
+    name=module_name,
+    version=version,
+    author="IRIS",
+    author_email="software-owner@iris.washington.edu",
+    description="Python hook for installing mseedindex",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/iris-edu/mseedindexpypy",
+    packages=find_packages(),
+    python_requires='>=2.7, <4',
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: Unix",
+        "Operating System :: MacOS",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+    ],
+    cmdclass={'install': InstallMSeedIndex,
+              'develop': DevelopMSeedIndex},
+)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools.command.develop import develop
 from setuptools.command.sdist import sdist
 from io import open
 from tempfile import gettempdir
+import pkg_resources
 import subprocess
 import os
 import sys
@@ -27,6 +28,7 @@ except ImportError:
 
 dist_options = dict(
     name=module_name,
+    version = pkg_resources.get_distribution(module_name).version,
     author="IRIS",
     author_email="software-owner@iris.washington.edu",
     description="Python hook for installing mseedindex",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ except ImportError:
 
 dist_options = dict(
     name=module_name,
-    version="0.0.0",  # automatically updated to mseeedindex.c version by sdist
     author="IRIS",
     author_email="software-owner@iris.washington.edu",
     description="Python hook for installing mseedindex",

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     description="Python hook for installing mseedindex",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/iris-edu/mseedindexpypy",
+    url="https://github.com/iris-edu/mseedindex",
     packages=find_packages(),
     python_requires='>=2.7, <4',
     classifiers=[


### PR DESCRIPTION
Adds a setup.py python file to enable installing mseedindex from PyPi. The setup.py program downloads mseedindex from GitHub and puts a compiled binary in the python path. A python program called mseedindex is also added to the python environment.

Please note that the compiled mseedindex binary that is placed in the environment path does not get removed when the mseedindex python program is uninstalled. This is because there is no way to do this within the constraints of setuptools. As a result, mseedindex needs to be manually removed after the python program is uninstalled.
