### PR TITLE
Fix Windows Nmake build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 *.dylib
 *.so
 *.dll
+# C build object (Windows)
+*.obj
+*.lib
+*.exe
 
 # Distribution / packaging
 build/

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -12,8 +12,8 @@ BIN = ..\mseedindex.exe
 
 all: $(BIN)
 
-$(BIN):	mseedindex.obj md5.obj asprintf.obj ..\sqlite\sqlite3.obj
-	link.exe /nologo /out:$(BIN) $(LIBS) mseedindex.obj md5.obj asprintf.obj sqlite3.obj
+$(BIN):	mseedindex.obj md5.obj sha256.obj asprintf.obj ..\sqlite\sqlite3.obj
+	link.exe /nologo /out:$(BIN) $(LIBS) mseedindex.obj md5.obj sha256.obj asprintf.obj sqlite3.obj
 
 .c.obj:
         $(CC) /nologo $(CFLAGS) $(INCS) $(OPTS) /c $<


### PR DESCRIPTION
Add missing `sha256.obj` to the linking stage in `src/Makefile.win`. Also update `.gitignore` with Windows-specific build objects.
After that build process on Windows works flawlessly.