### PR TITLE
Python wrapper: create a path to executable within a separate function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,4 @@ packages = ["mseedindex"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "python/__main__.py" = "mseedindex/__main__.py"
+"python/__init__.py" = "mseedindex/__init__.py"

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+def get_path_to_binary() -> Path:
+    """
+    Returns a path to a binary of mseedindex, regardless of the OS.
+    """
+    if sys.platform.lower().startswith("win"):
+        binary_name = "mseedindex.exe"
+    else:
+        binary_name = "mseedindex"
+
+    binary_path = Path(__file__).parent / binary_name
+    return binary_path
+

--- a/python/__main__.py
+++ b/python/__main__.py
@@ -1,15 +1,10 @@
 # A Python wrapper for PyPI packaging entry point
-import subprocess
+import subprocess 
 import sys
-from pathlib import Path
+
+from mseedindex import get_path_to_binary
 
 def main():
-    if sys.platform.lower().startswith("win"):
-        binary_name = "mseedindex.exe"
-    else:
-        binary_name = "mseedindex"
-
-    binary_path = Path(__file__).parent / binary_name
-
+    binary_path = get_path_to_binary()
     result = subprocess.run([str(binary_path)] + sys.argv[1:])
     sys.exit(result.returncode)

--- a/src/mseedindex.c
+++ b/src/mseedindex.c
@@ -114,7 +114,7 @@
 #include "md5.h"
 #include "sha256.h"
 
-#define VERSION "3.0.8"
+#define VERSION "3.0.9"
 #define PACKAGE "mseedindex"
 
 static flag verbose = 0;


### PR DESCRIPTION
Hey!

Thanks for great additions to the project, last time I looked at it was in ~2020 so there were a few! Especially the json mode is great, it allowed me to remove hard dependency on mseedindex's DB schema in my app. Thanks Chad!

The change I am proposing is mostly due to the fact I am using mseedindex in my python app. I need to call it from python code via subprocess hence I need a path to a binary. I could rely on PATH but it feels quite fragile. Having a path delivered from the python package itself feels much cleaner. 

I had to bump the version of mseedindex since the python package doesn't maintain its own ver.

What do you think?