### PR TITLE
hash: fix only get one file's hash

### DIFF
--- a/src/mseedindex.c
+++ b/src/mseedindex.c
@@ -451,7 +451,7 @@ main (int argc, char **argv)
   {
     md5_byte_t digest[16];
 
-    secid = filelist->mstl->traces.next[0];
+    secid = flp->mstl->traces.next[0];
     while (secid)
     {
       if ((sd = (struct sectiondetails *)secid->prvtptr))


### PR DESCRIPTION
In the session to obtain all files' hashes, use 'flp replace filelist'; otherwise, only the first file's hash value will be obtained.

```
  id  | network | station | location | channel | quality | version |       starttime        |        endtime         | samplerate |                                                     filename                                                      | byteoffset | bytes  |               hash               |                                                                                                                                                                                                                                                                                                                                                                             timeindex                                                                                                                                                                                                                                                                                                                                                                              |                 timespans                 | timerates | format |      filemodtime       |        updated         |        scanned
------+---------+---------+----------+---------+---------+---------+------------------------+------------------------+------------+-------------------------------------------------------------------------------------------------------------------+------------+--------+----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------+-----------+--------+------------------------+------------------------+------------------------
 1455 | CI      | PASC    | 00       | LHZ     |         |       2 | 2016-04-01 08:00:00+08 | 2016-04-02 07:59:59+08 |          1 | /home/wangf23/earthquake/cuteventWithCIDemo/demodataCI2016/mseed/2016092/CI.PASC.00.LHZ.D.2016.092.00.00.00.mseed |          0 | 188416 | a3d17b94a67a0b782833d3bbfd643fe0 | "latest"=>"1", "1459468800.000000"=>"0", "1459470686.000000"=>"4096", "1459474458.000000"=>"12288", "1459478230.000000"=>"20480", "1459482002.000000"=>"28672", "1459485774.000000"=>"36864", "1459489546.000000"=>"45056", "1459493318.000000"=>"53248", "1459497090.000000"=>"61440", "1459500862.000000"=>"69632", "1459504634.000000"=>"77824", "1459506520.000000"=>"81920", "1459510292.000000"=>"90112", "1459514064.000000"=>"98304", "1459517836.000000"=>"106496", "1459521608.000000"=>"114688", "1459525382.000000"=>"122880", "1459529154.000000"=>"131072", "1459532926.000000"=>"139264", "1459536698.000000"=>"147456", "1459540470.000000"=>"155648", "1459544242.000000"=>"163840", "1459546128.000000"=>"167936", "1459549900.000000"=>"176128" | {"[1459468800.000000,1459555199.000000]"} |           |        | 2016-12-30 11:12:34+08 | 2016-12-30 11:12:34+08 | 2025-11-18 14:29:39+08
 1456 | CI      | PASC    | 00       | LHN     |         |       2 | 2016-04-01 08:00:00+08 | 2016-04-02 07:59:59+08 |          1 | /home/wangf23/earthquake/cuteventWithCIDemo/demodataCI2016/mseed/2016092/CI.PASC.00.LHN.D.2016.092.00.00.00.mseed |          0 | 188416 |                                  | "latest"=>"1", "1459468800.000000"=>"0", "1459470686.000000"=>"4096", "1459474458.000000"=>"12288", "1459478232.000000"=>"20480", "1459482004.000000"=>"28672", "1459485776.000000"=>"36864", "1459489548.000000"=>"45056", "1459493320.000000"=>"53248", "1459497092.000000"=>"61440", "1459500864.000000"=>"69632", "1459504636.000000"=>"77824", "1459506522.000000"=>"81920", "1459510294.000000"=>"90112", "1459514066.000000"=>"98304", "1459517838.000000"=>"106496", "1459521610.000000"=>"114688", "1459525382.000000"=>"122880", "1459529154.000000"=>"131072", "1459532926.000000"=>"139264", "1459536698.000000"=>"147456", "1459540470.000000"=>"155648", "1459544242.000000"=>"163840", "1459546130.000000"=>"167936", "1459549902.000000"=>"176128" | {"[1459468800.000000,1459555199.000000]"} |           |        | 2016-12-30 11:12:34+08 | 2016-12-30 11:12:34+08 | 2025-11-18 14:29:39+08
 1457 | CI      | WWC     |          | LHN     |         |       2 | 2016-04-01 08:00:00+08 | 2016-04-02 07:59:59+08 |          1 | /home/wangf23/earthquake/cuteventWithCIDemo/demodataCI2016/mseed/2016092/CI.WWC..LHN.D.2016.092.00.00.00.mseed    |          0 | 167936 |                                  | "latest"=>"1", "1459468800.000000"=>"0", "1459470952.000000"=>"4096", "1459475304.000000"=>"12288", "1459479572.000000"=>"20480", "1459481686.000000"=>"24576", "1459485942.000000"=>"32768", "1459490194.000000"=>"40960", "1459492316.000000"=>"45056", "1459496540.000000"=>"53248", "1459500792.000000"=>"61440", "1459502918.000000"=>"65536", "1459507180.000000"=>"73728", "1459511426.000000"=>"81920", "1459513624.000000"=>"86016", "1459517860.000000"=>"94208", "1459522008.000000"=>"102400", "1459526262.000000"=>"110592", "1459528376.000000"=>"114688", "1459532582.000000"=>"122880", "1459536788.000000"=>"131072", "1459538886.000000"=>"135168", "1459543152.000000"=>"143360", "1459547318.000000"=>"151552", "1459551486.000000"=>"159744"  | {"[1459468800.000000,1459555199.000000]"} |           |        | 2016-12-30 11:12:34+08 | 2016-12-30 11:12:34+08 | 2025-11-18 14:29:39+08
```
 